### PR TITLE
【代码迁移】任务46：Scaling transition from momentum stochastic gradient descent to plain stochastic gradient descent

### DIFF
--- a/application/TSGD/README.md
+++ b/application/TSGD/README.md
@@ -1,0 +1,20 @@
+## 运行
+
+1. 进入tsgd目录
+```
+ cd tsgd
+```
+
+2. 下载MNIST数据集
+```
+!mkdir -p ./datasets/MNIST_Data/train ./datasets/MNIST_Data/test
+!wget -NP ./datasets/MNIST_Data/train https://mindspore-website.obs.myhuaweicloud.com/notebook/datasets/mnist/train-labels-idx1-ubyte --no-check-certificate
+!wget -NP ./datasets/MNIST_Data/train https://mindspore-website.obs.myhuaweicloud.com/notebook/datasets/mnist/train-images-idx3-ubyte --no-check-certificate
+!wget -NP ./datasets/MNIST_Data/test https://mindspore-website.obs.myhuaweicloud.com/notebook/datasets/mnist/t10k-labels-idx1-ubyte --no-check-certificate
+!wget -NP ./datasets/MNIST_Data/test https://mindspore-website.obs.myhuaweicloud.com/notebook/datasets/mnist/t10k-images-idx3-ubyte --no-check-certificate
+```
+
+3. 运行训练脚本
+```
+ python main.py
+````

--- a/application/TSGD/tsgd/__init__.py
+++ b/application/TSGD/tsgd/__init__.py
@@ -1,0 +1,1 @@
+from .tsgd import *

--- a/application/TSGD/tsgd/main.py
+++ b/application/TSGD/tsgd/main.py
@@ -1,0 +1,100 @@
+import mindspore as ms
+from mindspore import nn, dataset as ds, Model, context
+from mindvision.dataset import Mnist
+from mindspore.train.callback import Callback
+import math
+from tsgd import TSGD
+
+# 设置mindspore随机种子
+ms.set_seed(0)
+
+# 1. 设置训练环境
+context.set_context(mode=context.GRAPH_MODE, device_target="CPU")  # 如果有GPU支持，可以将设备设置为"Ascend"
+
+# 2. 参数设置
+batch_size = 64
+num_epochs = 10
+learning_rate = 0.001
+
+# 3. 加载MNIST数据集
+def create_dataset(data_path, batch_size=64, training=True):
+    mnist_ds = Mnist(path=data_path, split="train" if training else "test", batch_size=batch_size, resize=28, download=False).run()
+    return mnist_ds
+
+train_dataset = create_dataset("./datasets/MNIST_Data", batch_size=batch_size, training=True)
+test_dataset = create_dataset("./datasets/MNIST_Data", batch_size=batch_size, training=False)
+
+# 4. 定义FFN网络
+class FeedforwardNeuralNet(nn.Cell):
+    def __init__(self, input_size=28*28, hidden_size=128, num_classes=10):
+        super(FeedforwardNeuralNet, self).__init__()
+        self.flatten = nn.Flatten()
+        # self.fc1 = nn.Dense(input_size, hidden_size, weight_init=Normal(0.02))
+        self.fc1 = nn.Dense(input_size, hidden_size)
+
+        self.relu = nn.ReLU()
+        # self.fc2 = nn.Dense(hidden_size, num_classes, weight_init=Normal(0.02))
+        self.fc2 = nn.Dense(hidden_size, num_classes)
+
+    def construct(self, x):
+        # print(x)
+        x = self.flatten(x)
+        # print(x)
+        # print(x.shape)
+        x = self.fc1(x)
+        x = self.relu(x)
+        x = self.fc2(x)
+        return x
+
+model = FeedforwardNeuralNet()
+
+# 5. 定义损失函数和优化器
+loss_fn = nn.CrossEntropyLoss()
+
+# 计算 iters
+trainSampleSize = 60000     # MNIST数据集的训练集包含 60,000 张手写数字图像
+iters = math.ceil(trainSampleSize / batch_size) * num_epochs
+
+# 构建优化器
+# optimizer = nn.SGD(model.trainable_params(), learning_rate=learning_rate)
+# optimizer = nn.Adagrad(model.trainable_params(), learning_rate=learning_rate)
+optimizer = TSGD(model.trainable_params(), iters=iters)
+
+
+# 6. 训练模型
+# 自定义回调函数计算平均Loss
+class AverageLossCallback(Callback):
+    def __init__(self):
+        self.epoch_loss = 0
+        self.steps = 0
+
+    def epoch_begin(self, run_context):
+        # 每个 epoch 开始时重置 loss 和步数计数
+        self.epoch_loss = 0
+        self.steps = 0
+
+    def step_end(self, run_context):
+        cb_params = run_context.original_args()
+        self.epoch_loss += cb_params.net_outputs.asnumpy()
+        self.steps += 1
+
+    def epoch_end(self, run_context):
+        cb_params = run_context.original_args()
+        avg_loss = self.epoch_loss / self.steps
+        print(f"Epoch [{cb_params.cur_epoch_num}], Average Loss: {avg_loss:.4f}")
+
+def train(model, train_dataset, loss_fn, optimizer, num_epochs):
+    model = Model(model, loss_fn=loss_fn, optimizer=optimizer, metrics={'accuracy'})
+    print("Training...")
+    model.train(num_epochs, train_dataset, callbacks=[AverageLossCallback()], dataset_sink_mode=False)
+
+# 7. 测试模型
+def evaluate(model, test_dataset):
+    model = Model(model, loss_fn=loss_fn, optimizer=optimizer, metrics={'accuracy'})
+    print("Evaluating...")
+    acc = model.eval(test_dataset, dataset_sink_mode=False)
+    print(f"Test Accuracy: {acc['accuracy'] * 100:.2f}%")
+
+# 8. 执行训练和评估
+train(model, train_dataset, loss_fn, optimizer, num_epochs)
+evaluate(model, test_dataset)

--- a/application/TSGD/tsgd/tsgd.py
+++ b/application/TSGD/tsgd/tsgd.py
@@ -1,0 +1,90 @@
+import math
+from mindspore import nn, Parameter
+from mindspore.common import Tensor
+import mindspore as ms
+import mindspore.ops as ops
+
+
+class TSGD(nn.Optimizer):
+    r"""Implements: Scaling transition from SGDM to plain SGD.
+    'https://arxiv.org/abs/2106.06753'
+    
+    Nesterov momentum is based on the formula from
+    `On the importance of initialization and momentum in deep learning`.
+
+    Args:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups
+        iters(int): iterations
+            iters = math.ceil(trainSampleSize / batchSize) * epochs
+        lr (float): learning rate 
+        momentum (float, optional): momentum factor (default: 0)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        dampening (float, optional): dampening for momentum (default: 0)
+        nesterov (bool, optional): enables Nesterov momentum (default: False)
+        coeff(float, optional): scaling coefficient
+    """
+
+    def __init__(self, params, iters, momentum=0.9, dampening=0, weight_decay=0, nesterov=False, up_lr=5e-1, low_lr=5e-3, coeff1=1e-2, coeff2=5e-4):
+        if not 1 <= iters:
+            raise ValueError("Invalid iters: {}".format(iters))             
+        if momentum <= 0.0:
+            raise ValueError("Invalid momentum value: {}".format(momentum))
+        if weight_decay < 0.0:
+            raise ValueError("Invalid weight_decay value: {}".format(weight_decay))
+        if not 0.0 <= coeff1 <= 1.0:
+            raise ValueError("Invalid coeff1: {}".format(coeff1))            
+        if not 0.0 <= coeff2 <= 1.0:
+            raise ValueError("Invalid coeff2: {}".format(coeff2))                      
+        if not 0.0 <= up_lr:
+            raise ValueError("Invalid up learning rate: {}".format(up_lr))
+        if not 0.0 <= low_lr:
+            raise ValueError("Invalid low learning rate: {}".format(low_lr))            
+        if not low_lr <= up_lr:
+            raise ValueError("required up_lr >= low_lr, but (up_lr = {}, low_lr = {})".format(up_lr, low_lr))                  
+
+        super(TSGD, self).__init__(up_lr, params)
+        self.iters = iters
+        self.momentum = momentum
+        self.dampening = dampening
+        self.weight_decay = weight_decay
+        self.nesterov = nesterov
+        self.up_lr = up_lr
+        self.low_lr = low_lr
+        self.coeff1 = coeff1
+        self.coeff2 = coeff2
+        self.moments = self.parameters.clone(prefix="moments", init="zeros")
+        self.steps = self.parameters.clone(prefix="steps", init="zeros")
+
+    def construct(self, grads):
+        params = self.parameters
+        for i, (param, grad) in enumerate(zip(params, grads)):
+            if grad is None:
+                continue
+            if self.weight_decay != 0:
+                grad += param * self.weight_decay
+            step = self.steps[i]
+            buf = self.moments[i]
+            ops.assign(self.steps[i], self.steps[i] + 1)
+            ops.assign(self.moments[i], self.moments[i] * self.momentum + grad * (1 - self.dampening))
+
+            if self.nesterov:
+                grad = grad + buf * self.momentum
+
+            rho1 = 10 ** (math.log(self.coeff1, 10) / self.iters)
+            rho2 = 10 ** (math.log(self.coeff2, 10) / self.iters)
+
+            grad = (buf - grad) * (rho1 ** step) + grad
+            lr = ((self.up_lr - self.low_lr) * rho2 ** step + self.low_lr) * (1 - rho2 ** step)
+
+            param = ops.assign_sub(param, grad * lr)
+        return params
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
1. 使用mindspore复现了论文《Scaling transition from momentum stochastic gradient descent to plain stochastic gradient descent》代码仓库中的TSGD优化器。(issue编号：https://gitee.com/mindspore/community/issues/IAYZGP   ）
2. 编写了main.py对TSGD优化器进行了测试，测试任务为基于MNIST数据集训练一个FFN。
3. 对比不同优化器在torch和minspore框架下的测试结果如下：
![image](https://github.com/user-attachments/assets/3486ce19-7afe-415f-822b-afe390254991)

‘可知，基于mindspore框架的TSGD优化器复现了基于torch框架的TSGD优化器结果。




