### PR TITLE
【代码迁移】任务62：优化器lamb和dowg

### DIFF
--- a/application/DoWG-Unleashed/dowg.py
+++ b/application/DoWG-Unleashed/dowg.py
@@ -1,0 +1,67 @@
+import mindspore as ms
+from mindspore import nn, ops, Parameter, Tensor
+from mindspore.common.initializer import initializer
+
+class DoWG(nn.Optimizer):
+    """
+    实现 DoWG（Distance over Weight Gradient）优化算法。
+
+    参数：
+        parameters (list): 待优化的参数列表。
+        learning_rate (float): 学习率，默认值为 0.001。
+        eps (float): 增加到分母以提高数值稳定性的项，默认值为 1e-4。
+    """
+    def __init__(self, parameters, learning_rate=0.001, eps=1e-4):
+        super(DoWG, self).__init__(learning_rate=learning_rate, parameters=parameters)
+        self.eps = eps
+        self.rt2 = Parameter(initializer(Tensor([eps], ms.float32), [1]), name="rt2")
+        self.vt = Parameter(initializer(Tensor([0.0], ms.float32), [1]), name="vt")
+        self.x0 = [Parameter(p.clone(), name=f"x0_{i}") for i, p in enumerate(parameters)]
+
+        self.assign = ops.Assign()
+        self.assign_add = ops.AssignAdd()
+
+    def construct(self, gradients):
+        grad_sq_norm = ops.zeros((1,), ms.float32)
+        curr_d2 = ops.zeros((1,), ms.float32)
+
+        for p, g, x0 in zip(self.parameters, gradients, self.x0):
+            grad_sq_norm += ops.reduce_sum(g ** 2)
+            curr_d2 += ops.reduce_sum((p - x0) ** 2)
+
+        new_rt2 = ops.maximum(self.rt2, curr_d2)
+        self.assign(self.rt2, new_rt2)
+        self.assign_add(self.vt, self.rt2 * grad_sq_norm)
+
+        denom = ops.sqrt(self.vt) + self.eps
+
+        for p, g in zip(self.parameters, gradients):
+            gt_hat = self.rt2 * g
+            new_p = p - gt_hat / denom
+            self.assign(p, new_p)
+
+        return True
+
+class CDoWG(nn.Optimizer):
+    """
+    实现 CDoWG（Coordinate-wise Distance over Weight Gradient）优化算法。
+    参数：
+        params (list): 待优化的参数列表。
+        eps (float): 增加到分母以提高数值稳定性的项，默认值为 1e-8。
+    """
+    def __init__(self, params, eps=1e-8):
+        super(CDoWG, self).__init__(learning_rate=0.001, params=params)
+        self.eps = eps
+        self.x0 = [Parameter(p.clone(), name=f"x0_{i}") for i, p in enumerate(params)]
+        self.rt2 = [Parameter(initializer(1e-4, p.shape, ms.float32), name=f"rt2_{i}") for i, p in enumerate(params)]
+        self.vt = [Parameter(initializer(0, p.shape, ms.float32), name=f"vt_{i}") for i, p in enumerate(params)]
+
+    def construct(self, gradients):
+        for p, g, x0, rt2, vt in zip(self.parameters, gradients, self.x0, self.rt2, self.vt):
+            rt2 = ops.maximum(rt2, (p - x0) ** 2)
+            vt += rt2 * g ** 2
+            gt_hat = rt2 * g
+            denom = ops.sqrt(vt) + self.eps
+            p = p - gt_hat / denom
+
+        return True

--- a/application/Large-Batch-Optimization-for-Deep-Learning/lamb.py
+++ b/application/Large-Batch-Optimization-for-Deep-Learning/lamb.py
@@ -1,0 +1,65 @@
+import mindspore as ms
+from mindspore import nn, ops, Parameter
+from mindspore.common.initializer import initializer
+
+class Lamb(nn.Optimizer):
+    """
+    实现LAMB（Layer-wise Adaptive Moments optimizer for Batching training）优化算法。
+    参数：
+        params (list): 待优化的参数列表。
+        learning_rate (float): 学习率，默认值为1e-3。
+        beta1 (float): 一阶矩估计的指数衰减率，默认值为0.9。
+        beta2 (float): 二阶矩估计的指数衰减率，默认值为0.999。
+        eps (float): 为提高数值稳定性添加到分母的项，默认值为1e-6。
+        weight_decay (float): 权重衰减（L2正则化），默认值为0。
+    """
+    def __init__(self, params, learning_rate=1e-3, beta1=0.9, beta2=0.999, eps=1e-6, weight_decay=0.0):
+        super(Lamb, self).__init__(learning_rate, params)
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.eps = eps
+        self.weight_decay = weight_decay
+
+        # 初始化状态变量
+        self.moments1 = self.parameters.clone(prefix="moments1", init='zeros')
+        self.moments2 = self.parameters.clone(prefix="moments2", init='zeros')
+        self.steps = Parameter(initializer(0, [1], ms.int32), name="steps")
+
+    def construct(self, gradients):
+        lr = self.get_lr()
+        updated_params = []
+
+        self.steps += 1
+        beta1_t = self.beta1 ** self.steps
+        beta2_t = self.beta2 ** self.steps
+
+        for i, (param, grad) in enumerate(zip(self.parameters, gradients)):
+            if grad is None:
+                continue
+
+            m = self.moments1[i]
+            v = self.moments2[i]
+
+            m = self.beta1 * m + (1 - self.beta1) * grad
+            v = self.beta2 * v + (1 - self.beta2) * ops.square(grad)
+
+            m_hat = m / (1 - beta1_t)
+            v_hat = v / (1 - beta2_t)
+
+            adam_step = m_hat / (ops.sqrt(v_hat) + self.eps)
+
+            if self.weight_decay != 0:
+                adam_step += self.weight_decay * param
+
+            weight_norm = ops.norm(param)
+            adam_norm = ops.norm(adam_step)
+            trust_ratio = ops.select(weight_norm > 0, ops.select(adam_norm > 0, weight_norm / adam_norm, 1.0), 1.0)
+
+            new_param = param - lr * trust_ratio * adam_step
+            updated_params.append(new_param)
+
+            ops.assign(param, new_param)
+            ops.assign(self.moments1[i], m)
+            ops.assign(self.moments2[i], v)
+
+        return updated_params


### PR DESCRIPTION
运行截图：
任务一：优化器LAMB的运行截图
<img width="532" alt="image" src="https://github.com/user-attachments/assets/ccb09011-9af6-45b7-9d61-228cc4e8fb27">
任务二：优化器DOWG的运行截图
<img width="398" alt="image" src="https://github.com/user-attachments/assets/e7a25260-d136-49b3-8133-951810a8c639">
由于迁移代码是两个优化器，我使用了以下简单的网络结构测试：


```markdown
import mindspore as ms
from mindspore import nn, ops, Parameter, Tensor
from mindspore.common.initializer import initializer
import numpy as np
from dowg import DoWG
from lamb import Lamb
# 定义简单网络以测试
class SimpleNet(nn.Cell):
    def __init__(self, input_size, output_size):
        super(SimpleNet, self).__init__()
        self.fc = nn.Dense(input_size, output_size)

    def construct(self, x):
        return self.fc(x)
np.random.seed(0)
input_data = np.random.randn(100, 1).astype(np.float32)
labels = 2 * input_data + 1
input_tensor = Tensor(input_data)
label_tensor = Tensor(labels)
net = SimpleNet(input_size=1, output_size=1)
loss_fn = nn.MSELoss()
optimizer = DoWG(parameters=net.trainable_params(), eps=1e-4)
# optimizer = Lamb(params=net.trainable_params(), learning_rate=0.01)
def forward_fn(data, label):
    logits = net(data)
    loss = loss_fn(logits, label)
    return loss, logits
grad_fn = ops.value_and_grad(forward_fn, None, optimizer.parameters, has_aux=True)
num_epochs = 100
for epoch in range(num_epochs):
    (loss, _), grads = grad_fn(input_tensor, label_tensor)
    optimizer(grads)
    print(f"Epoch {epoch + 1}, Loss: {loss.asnumpy()}")
```
