### PR TITLE
【代码迁移】任务48-1：Overcoming catastrophic forgetting in neural networks

### DIFF
--- a/application/EWC-Overcoming-catastrophic-forgetting/demo.ipynb
+++ b/application/EWC-Overcoming-catastrophic-forgetting/demo.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "  setattr(self, word, getattr(machar, word).flat[0])\n",
+      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float64'> type is zero.\n",
+      "  return self._float_to_str(self.smallest_subnormal)\n",
+      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:499: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "  setattr(self, word, getattr(machar, word).flat[0])\n",
+      "/home/ma-user/anaconda3/envs/MindSpore/lib/python3.9/site-packages/numpy/core/getlimits.py:89: UserWarning: The value of the smallest subnormal for <class 'numpy.float32'> type is zero.\n",
+      "  return self._float_to_str(self.smallest_subnormal)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import mindspore\n",
+    "from mindspore import nn, ops\n",
+    "from mindspore.dataset import MnistDataset, FashionMnistDataset, vision, transforms\n",
+    "from elastic_weight_consolidation import ElasticWeightConsolidation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_transforms = [\n",
+    "                    vision.Rescale(1.0 / 255.0, 0),\n",
+    "                    #vision.Normalize(mean = (0.1307, ), std = (0.3081, )),\n",
+    "                    vision.HWC2CHW()\n",
+    "]\n",
+    "label_transform = transforms.TypeCast(mindspore.int32)\n",
+    "mnist_train = MnistDataset(\"MNIST_Data/train\", usage = \"train\", shuffle = True)\n",
+    "mnist_train = mnist_train.map(image_transforms, 'image')\n",
+    "mnist_train = mnist_train.map(label_transform, 'label')\n",
+    "mnist_train = mnist_train.batch(100)\n",
+    "mnist_test = MnistDataset(\"MNIST_Data/test\", usage = \"test\", shuffle = False)\n",
+    "mnist_test = mnist_test.map(image_transforms, 'image')\n",
+    "mnist_test = mnist_test.map(label_transform, 'label')\n",
+    "mnist_test = mnist_test.batch(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LinearLayer(nn.Cell):\n",
+    "    \n",
+    "    def __init__(self, input_dim, output_dim, act = 'relu', use_bn = False):\n",
+    "        super(LinearLayer, self).__init__()\n",
+    "        self.use_bn = use_bn\n",
+    "        self.lin = nn.Dense(input_dim, output_dim)\n",
+    "        self.act = nn.ReLU() if act == 'relu' else act\n",
+    "        if use_bn:\n",
+    "            self.bn = nn.BatchNorm1d(output_dim)\n",
+    "            \n",
+    "    def construct(self, x):\n",
+    "        if self.use_bn:\n",
+    "            return self.bn(self.act(self.lin(x)))\n",
+    "        return self.act(self.lin(x))\n",
+    "\n",
+    "class Flatten(nn.Cell):\n",
+    "\n",
+    "    def construct(self, x):\n",
+    "        return x.view(x.shape[0], -1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BaseModel(nn.Cell):\n",
+    "    \n",
+    "    def __init__(self, num_inputs, num_hidden, num_outputs):\n",
+    "        super(BaseModel, self).__init__()\n",
+    "        self.f1 = Flatten()\n",
+    "        self.lin1 = LinearLayer(num_inputs, num_hidden, use_bn = True)\n",
+    "        self.lin2 = LinearLayer(num_hidden, num_hidden, use_bn = True)\n",
+    "        self.lin3 = nn.Dense(num_hidden, num_outputs)\n",
+    "        \n",
+    "    def construct(self, x):\n",
+    "        return self.lin3(self.lin2(self.lin1(self.f1(x))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crit = nn.CrossEntropyLoss()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ewc = ElasticWeightConsolidation(BaseModel(28 * 28, 100, 10), crit = crit, lr = 1e-4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tqdm import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "600it [00:14, 40.11it/s]\n",
+      "600it [00:07, 77.80it/s]\n",
+      "600it [00:07, 76.44it/s]\n",
+      "600it [00:07, 78.07it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for _ in range(4):\n",
+    "    for input, target in tqdm(mnist_train.create_tuple_iterator()):\n",
+    "        ewc.forward_backward_update(input, target)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-\r"
+     ]
+    }
+   ],
+   "source": [
+    "ewc.register_ewc_params(mnist_train, 100, 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f_mnist_train = FashionMnistDataset(\"FashionMNIST_Data/train\", usage = \"train\", shuffle = True)\n",
+    "f_mnist_train = f_mnist_train.map(image_transforms, 'image')\n",
+    "f_mnist_train = f_mnist_train.map(label_transform, 'label')\n",
+    "f_mnist_train = f_mnist_train.batch(100)\n",
+    "f_mnist_test = FashionMnistDataset(\"FashionMNIST_Data/test\", usage = \"test\", shuffle = False)\n",
+    "f_mnist_test = f_mnist_test.map(image_transforms, 'image')\n",
+    "f_mnist_test = f_mnist_test.map(label_transform, 'label')\n",
+    "f_mnist_test = f_mnist_test.batch(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "600it [00:17, 35.11it/s]\n",
+      "600it [00:16, 36.59it/s]\n",
+      "600it [00:16, 37.12it/s]\n",
+      "600it [00:15, 38.26it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for _ in range(4):\n",
+    "    for input, target in tqdm(f_mnist_train.create_tuple_iterator()):\n",
+    "        ewc.forward_backward_update(input, target)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ewc.register_ewc_params(f_mnist_train, 100, 300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def accu(model, dataset):\n",
+    "    model.set_train(False)\n",
+    "    acc = 0\n",
+    "    for input, target in dataset.create_tuple_iterator():\n",
+    "        o = model(input)\n",
+    "        acc += (o.argmax(axis = 1).long() == target).float().mean()\n",
+    "    return acc / dataset.get_batch_size()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\\\r"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tensor(shape=[], dtype=Float32, value= 0.8171)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "accu(ewc.model, f_mnist_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Tensor(shape=[], dtype=Float32, value= 0.649)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "accu(ewc.model, mnist_test)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "MindSpore",
+   "language": "python",
+   "name": "mindspore"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/application/EWC-Overcoming-catastrophic-forgetting/elastic_weight_consolidation.py
+++ b/application/EWC-Overcoming-catastrophic-forgetting/elastic_weight_consolidation.py
@@ -1,0 +1,69 @@
+import mindspore
+from mindspore import ops, nn, ParameterTuple
+
+class ElasticWeightConsolidation:
+
+    def __init__(self, model, crit, lr = 0.001, weight = 1000000):
+        self.model = model
+        self.weight = weight
+        self.crit = crit
+        self.optimizer = nn.Adam(self.model.trainable_params(), learning_rate = lr)
+        self.mean_params = {}
+        self.fisher_params = {}
+
+    def _update_mean_params(self):
+        for param in self.model.trainable_params():
+            self.mean_params[param.name] = param.copy()
+
+    def _loglikelihood_forward_fn(self, iterator, num_batch):
+        log_likelihoods = []
+        it = iterator
+        batch = 63 if num_batch > 63 else num_batch
+        for i in range(batch):
+            (input, target) = next(it)
+            output = ops.log_softmax(self.model(input), axis = 1)
+            log_likelihoods.append(output[:, target])
+        log_likelihood = ops.concat(log_likelihoods).mean()
+        return log_likelihood
+
+    def _update_fisher_params(self, current_ds, batch_size, num_batch):
+        current_ds.batch(batch_size)
+        iterator = current_ds.create_tuple_iterator()
+        grad_logliklihood_fn = mindspore.grad(self._loglikelihood_forward_fn, None, self.model.trainable_params())
+        grad_logliklihood = grad_logliklihood_fn(iterator,num_batch)
+        for param, grad in zip(self.model.trainable_params(), grad_logliklihood):
+            self.fisher_params[param.name] = grad.copy() ** 2
+
+    def register_ewc_params(self, dataset, batch_size, num_batches):
+        self._update_fisher_params(dataset, batch_size, num_batches)
+        self._update_mean_params()
+
+    def _compute_consolidation_loss(self, weight):
+        try:
+            losses = []
+            for param in self.model.trainable_params():
+                mean = self.mean_params.get(param.name)
+                fisher = self.fisher_params.get(param.name)
+                if mean is not None and fisher is not None:
+                    losses.append((fisher * (param - mean) ** 2).sum())
+            return (weight / 2) * sum(losses)
+        except AttributeError:
+            return 0
+    
+    def _forward_fn(self, input, target):
+        output = self.model(input)
+        loss = self._compute_consolidation_loss(self.weight) + self.crit(output, target)
+        return loss
+
+    def forward_backward_update(self, input, target):
+        self.model.set_train()
+        grad_fn = mindspore.value_and_grad(self._forward_fn, None, weights = self.model.trainable_params())
+        loss, grads = grad_fn(input, target)
+        self.optimizer(grads)
+
+    def save(self, filename):
+        mindspore.save_checkpoint(self.model, filename)
+
+    def load(self, filename):
+        mindspore.load_checkpoint(filename, self.model)
+        


### PR DESCRIPTION
第一期论文代码复现任务48-1：Overcoming catastrophic forgetting in neural networks
ISSUE链接：https://gitee.com/mindspore/community/issues/IAPGMY
可以实现与论文相同的功能（通过register_ewc_params函数来缓解灾难性遗忘）
第一个截图为有register_ewc_params，第二个截图为没有register_ewc_params，根据MNIST的测试结果，相比较下，EWC方法起到了效果。
但仍有一个无法解决的问题在于函数的最后一个参数num_batch，当num_batch大于63，由于自动微分机制内的splitD操作限制，导致出现错误，因此添加了选择（即num_batch大于63时，按照num_batch=63进行）。出现的问题如图3,4所示。
<img width="446" alt="ewc有" src="https://github.com/user-attachments/assets/5d560c02-a69b-4dd1-90c7-c5181cb9c291">

<img width="457" alt="ewc无" src="https://github.com/user-attachments/assets/41e51d3d-ace4-40f9-804c-4cbb734b35f6">
<img width="490" alt="7e4617640447b69edeb16003b9f49a3" src="https://github.com/user-attachments/assets/11355df5-79de-409a-9d62-85f4be88a8b5">
<img width="790" alt="704ee61ff657e5cf138af6f32a331eb" src="https://github.com/user-attachments/assets/b4e228d8-6286-4590-821b-412b3d432d69">
