### PR TITLE
【代码迁移】任务53-1：D-Unet_PyTorch

### DIFF
--- a/intern/D-Unet_PyTorch-master/DUnet_ms.py
+++ b/intern/D-Unet_PyTorch-master/DUnet_ms.py
@@ -1,0 +1,166 @@
+import mindspore as ms
+import mindspore.nn as nn
+import mindspore.ops as ops
+from mindspore.common.initializer import HeUniform, Zero, initializer
+
+from DUnet_parts_ms import *
+from loss_ms import *
+
+def weights_init_he(cell):
+    for _, child in cell.cells_and_names():
+        if isinstance(child, (nn.Conv2d, nn.Conv3d)):
+            child.weight.set_data(initializer(HeUniform(), child.weight.shape, child.weight.dtype))
+            if hasattr(child, 'bias') and child.bias is not None:
+                child.bias.set_data(initializer(Zero(), child.bias.shape, child.bias.dtype))
+
+class DUnet_ms(nn.Cell):
+    def __init__(self, in_channels_2d=4, in_channels_3d=1, weights_init=True):
+        super().__init__()
+        
+        self.in_channels_2d = in_channels_2d
+        self.in_channels_3d = in_channels_3d
+        
+        self.maxpool_2d = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.maxpool_3d = nn.MaxPool3d(kernel_size=2, stride=2)
+        self.dropout = nn.Dropout(p=0.3)
+        
+        # 3d down
+        self.bn_3d_1 = BN_block3d(in_channels_3d, 32)
+        self.bn_3d_2 = BN_block3d(32, 64)
+        self.bn_3d_3 = BN_block3d(64, 128)
+        
+        # 2d down
+        self.bn_2d_1 = BN_block2d(in_channels_2d, 32)
+        
+        self.bn_2d_2 = BN_block2d(32, 64)
+        self.se_add_2 = D_SE_Add(64, 64, 64)  # (2d_channels, out_channels, 3d_channels)
+        
+        self.bn_2d_3 = BN_block2d(64, 128)
+        self.se_add_3 = D_SE_Add(128, 128, 128)
+        
+        self.bn_2d_4 = BN_block2d(128, 256)
+        self.bn_2d_5 = BN_block2d(256, 512)
+        
+        # up
+        self.up_1 = UpBlock(512, 256)
+        self.bn_2d_6 = BN_block2d(512, 256)  # 256 + 256 = 512
+        
+        self.up_2 = UpBlock(256, 128)
+        self.bn_2d_7 = BN_block2d(256, 128)  # 128 + 128 = 256
+        
+        self.up_3 = UpBlock(128, 64)
+        self.bn_2d_8 = BN_block2d(128, 64)   # 64 + 64 = 128
+        
+        self.up_4 = UpBlock(64, 32)
+        self.bn_2d_9 = BN_block2d(64, 32)    # 32 + 32 = 64
+        
+        self.final_conv = nn.SequentialCell([
+            nn.Conv2d(32, 1, kernel_size=1, has_bias=False),
+            nn.Sigmoid()
+        ])
+        
+        # 拼接操作
+        self.concat = ops.Concat(axis=1)
+        
+        # 操作符定义
+        self.reduce_mean_op = ops.ReduceMean(keep_dims=True)
+        self.expand_dims_op = ops.ExpandDims()
+        self.tile_op = ops.Tile()
+        
+        # He initialization stated in the original paper
+        if weights_init:
+            weights_init_he(self)
+
+    def construct(self, x_2d, x_3d=None):   
+        # 如果没有提供3D输入，则从2D输入生成
+        if x_3d is None:
+            # 创建伪3D输入 - 用于演示，实际应用中应该使用真实的3D多模态数据
+            x_3d = self.reduce_mean_op(x_2d, 1)  # [batch, 1, H, W] - 修复参数调用
+            x_3d = self.expand_dims_op(x_3d, 2)  # [batch, 1, 1, H, W]
+            # 为了避免池化后维度消失，我们复制深度层
+            x_3d = self.tile_op(x_3d, (1, 1, 8, 1, 1))  # [batch, 1, 8, H, W]
+        
+        # 3d Stream
+        conv3d_1 = self.bn_3d_1(x_3d)       # [batch, 32, 8, H, W]
+        pool3d_1 = self.maxpool_3d(conv3d_1)  # [batch, 32, 4, H/2, W/2]
+        
+        conv3d_2 = self.bn_3d_2(pool3d_1)   # [batch, 64, 4, H/2, W/2]
+        pool3d_2 = self.maxpool_3d(conv3d_2)  # [batch, 64, 2, H/4, W/4]
+        
+        conv3d_3 = self.bn_3d_3(pool3d_2)   # [batch, 128, 2, H/4, W/4]
+        
+        # 2d Encoding
+        conv2d_1 = self.bn_2d_1(x_2d)       # [batch, 32, H, W]
+        pool2d_1 = self.maxpool_2d(conv2d_1)  # [batch, 32, H/2, W/2]
+        
+        conv2d_2 = self.bn_2d_2(pool2d_1)   # [batch, 64, H/2, W/2]
+        conv2d_2 = self.se_add_2(conv3d_2, conv2d_2)  # [batch, 64, H/2, W/2]
+        pool2d_2 = self.maxpool_2d(conv2d_2)  # [batch, 64, H/4, W/4]
+        
+        conv2d_3 = self.bn_2d_3(pool2d_2)   # [batch, 128, H/4, W/4]
+        conv2d_3 = self.se_add_3(conv3d_3, conv2d_3)  # [batch, 128, H/4, W/4]
+        pool2d_3 = self.maxpool_2d(conv2d_3)  # [batch, 128, H/8, W/8]
+        
+        conv2d_4 = self.bn_2d_4(pool2d_3)   # [batch, 256, H/8, W/8]
+        conv2d_4 = self.dropout(conv2d_4)
+        pool2d_4 = self.maxpool_2d(conv2d_4)  # [batch, 256, H/16, W/16]
+        
+        conv2d_5 = self.bn_2d_5(pool2d_4)   # [batch, 512, H/16, W/16]
+        conv2d_5 = self.dropout(conv2d_5)
+        
+        # Decoding
+        up_1 = self.up_1(conv2d_5)          # [batch, 256, H/8, W/8]
+        # 确保尺寸匹配
+        if up_1.shape[2:] != conv2d_4.shape[2:]:
+            up_1 = ops.interpolate(up_1, size=conv2d_4.shape[2:], mode='bilinear', align_corners=False)
+        merge_1 = self.concat([conv2d_4, up_1])  # [batch, 512, H/8, W/8]
+        conv2d_6 = self.bn_2d_6(merge_1)    # [batch, 256, H/8, W/8]
+        
+        up_2 = self.up_2(conv2d_6)          # [batch, 128, H/4, W/4]
+        if up_2.shape[2:] != conv2d_3.shape[2:]:
+            up_2 = ops.interpolate(up_2, size=conv2d_3.shape[2:], mode='bilinear', align_corners=False)
+        merge_2 = self.concat([conv2d_3, up_2])  # [batch, 256, H/4, W/4]
+        conv2d_7 = self.bn_2d_7(merge_2)    # [batch, 128, H/4, W/4]
+        
+        up_3 = self.up_3(conv2d_7)          # [batch, 64, H/2, W/2]
+        if up_3.shape[2:] != conv2d_2.shape[2:]:
+            up_3 = ops.interpolate(up_3, size=conv2d_2.shape[2:], mode='bilinear', align_corners=False)
+        merge_3 = self.concat([conv2d_2, up_3])  # [batch, 128, H/2, W/2]
+        conv2d_8 = self.bn_2d_8(merge_3)    # [batch, 64, H/2, W/2]
+        
+        up_4 = self.up_4(conv2d_8)          # [batch, 32, H, W]
+        if up_4.shape[2:] != conv2d_1.shape[2:]:
+            up_4 = ops.interpolate(up_4, size=conv2d_1.shape[2:], mode='bilinear', align_corners=False)
+        merge_4 = self.concat([conv2d_1, up_4])  # [batch, 64, H, W]
+        conv2d_9 = self.bn_2d_9(merge_4)    # [batch, 32, H, W]
+        
+        output = self.final_conv(conv2d_9)  # [batch, 1, H, W]
+        
+        return output
+
+if __name__ == "__main__":
+    ms.set_context(mode=ms.PYNATIVE_MODE, device_target="CPU")
+    
+    model = DUnet_ms(in_channels_2d=4, in_channels_3d=1)
+    
+    BATCH_SIZE = 4
+    H, W = 192, 192
+    
+    # 2D输入 (例如：多通道MRI切片)
+    x_2d = ms.Tensor(shape=(BATCH_SIZE, 4, H, W), dtype=ms.float32, 
+                     init=ms.common.initializer.Normal())
+    
+    # 3D输入 (可选，如果有真实的3D数据)
+    # x_3d = ms.Tensor(shape=(BATCH_SIZE, 1, 8, H, W), dtype=ms.float32, 
+    #                  init=ms.common.initializer.Normal())
+    
+    output = model(x_2d)  # 自动生成3D输入
+    # output = model(x_2d, x_3d)  # 如果有真实3D输入
+    
+    print(f"Output shape: {output.shape}")
+    
+    y_true = ms.Tensor(shape=(BATCH_SIZE, 1, H, W), dtype=ms.float32,
+                      init=ms.common.initializer.Uniform())
+    loss = enhanced_mixing_loss(y_true, output)
+    print(f"Loss: {loss}")
+        

--- a/intern/D-Unet_PyTorch-master/DUnet_parts_ms.py
+++ b/intern/D-Unet_PyTorch-master/DUnet_parts_ms.py
@@ -1,0 +1,104 @@
+import mindspore as ms
+import mindspore.nn as nn
+import mindspore.ops as ops
+
+class SE_block(nn.Cell):
+    def __init__(self, in_channels, ratio=16):
+        super().__init__()
+        self.global_avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.fc1 = nn.Dense(in_channels, in_channels // ratio, has_bias=False)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Dense(in_channels // ratio, in_channels, has_bias=False)
+        self.sigmoid = nn.Sigmoid()
+        self.reshape = ops.Reshape()
+
+    def construct(self, x):
+        b, c, _, _ = x.shape
+        # Global Average Pooling
+        y = self.global_avg_pool(x)  # [b, c, 1, 1]
+        y = self.reshape(y, (b, c))  # [b, c]
+        
+        # FC layers
+        y = self.fc1(y)
+        y = self.relu(y)
+        y = self.fc2(y)
+        y = self.sigmoid(y)
+        
+        # Reshape and multiply
+        y = self.reshape(y, (b, c, 1, 1))
+        return x * y
+
+class BN_block2d(nn.Cell):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.block = nn.SequentialCell([
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, pad_mode='pad', has_bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1, pad_mode='pad', has_bias=False),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU()
+        ])
+
+    def construct(self, x):
+        return self.block(x)
+
+class BN_block3d(nn.Cell):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.block = nn.SequentialCell([
+            nn.Conv3d(in_channels, out_channels, kernel_size=3, padding=1, pad_mode='pad', has_bias=False),
+            nn.BatchNorm3d(out_channels),
+            nn.ReLU(),
+            nn.Conv3d(out_channels, out_channels, kernel_size=3, padding=1, pad_mode='pad', has_bias=False),
+            nn.BatchNorm3d(out_channels),
+            nn.ReLU()
+        ])
+
+    def construct(self, x):
+        return self.block(x)
+
+class D_SE_Add(nn.Cell):
+    def __init__(self, in_channels_2d, out_channels, mid_channels_3d):
+        super().__init__()
+        self.se_2d = SE_block(in_channels_2d)
+        self.conv3d_1x1 = nn.Conv3d(mid_channels_3d, mid_channels_3d, kernel_size=1, has_bias=False)
+        
+        self.conv2d = nn.Conv2d(mid_channels_3d, out_channels, kernel_size=3, padding=1, pad_mode='pad', has_bias=False)
+        self.relu = nn.ReLU()
+        self.se_3d_to_2d = SE_block(out_channels)
+        
+        # 操作符
+        self.reduce_mean_op = ops.ReduceMean(keep_dims=False)
+        self.squeeze_op = ops.Squeeze(2)
+
+    def construct(self, x_3d, x_2d):
+        x_2d = self.se_2d(x_2d)
+        x_3d = self.conv3d_1x1(x_3d)  # [N, C, D, H, W]
+        
+        # 3D转2D：在深度维度取平均或直接squeeze
+        if x_3d.shape[2] == 1:
+            x_3d = self.squeeze_op(x_3d)  # [N, C, 1, H, W] -> [N, C, H, W]
+        else:
+            x_3d = self.reduce_mean_op(x_3d, 2)  # [N, C, D, H, W] -> [N, C, H, W]
+        
+        x_3d = self.conv2d(x_3d)
+        x_3d = self.relu(x_3d)
+        x_3d = self.se_3d_to_2d(x_3d)
+        
+        return x_2d + x_3d
+
+class UpBlock(nn.Cell):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1, pad_mode='pad', has_bias=False)
+        self.relu = nn.ReLU()
+
+    def construct(self, x):
+        _, _, h, w = x.shape
+        target_h, target_w = h * 2, w * 2
+
+        x = ops.interpolate(x, size=(target_h, target_w), mode='bilinear', align_corners=False)
+        x = self.conv(x)
+        x = self.relu(x)
+        return x

--- a/intern/D-Unet_PyTorch-master/README.md
+++ b/intern/D-Unet_PyTorch-master/README.md
@@ -1,0 +1,37 @@
+# D-Unet - MindSpore
+
+This code is a mindspore implementation of D-Unet 
+
+## Usage
+
+```python
+import mindspore as ms
+import mindspore.nn as nn
+import mindspore.ops as ops
+from mindspore.common.initializer import HeUniform, Zero, initializer
+
+from DUnet_parts_ms import *
+from loss_ms import *
+
+BATCH_SIZE = 4
+x_2d = ms.Tensor(shape=(BATCH_SIZE, 4, H, W), dtype=ms.float32, init=ms.common.initializer.Normal()) #2D输入 (例如：多通道MRI切片)
+#x_3d = ms.Tensor(shape=(BATCH_SIZE, 1, 8, H, W), dtype=ms.float32, init=ms.common.initializer.Normal())  #3D输入 (可选，如果有真实的3D数据)
+
+model = DUnet_ms(in_channels_2d=4, in_channels_3d=1)
+
+output = model(x_2d)  # 自动生成3D输入
+# output = model(x_2d, x_3d)  # 如果有真实3D输入
+```
+
+- According to the Reference paper input size must be (4, 192, 192) and output size must be (1, 192, 192)
+
+## Project Structure
+- DUnet_ms.py
+    - DUnet_parts_ms.py
+    - loss_ms.py
+
+## Reference
+
+[1] Yongjin Zhou et al., D-UNet: a dimension-fusion U shape network for chronic stroke lesion segmentation ([ arXiv:1908.05104](https://arxiv.org/abs/1908.05104) [eess.IV] ), 2019 Aug
+
+[2] SZUHvern github source code implemented with keras (https://github.com/SZUHvern/D-UNet)

--- a/intern/D-Unet_PyTorch-master/loss_ms.py
+++ b/intern/D-Unet_PyTorch-master/loss_ms.py
@@ -1,0 +1,32 @@
+import mindspore as ms
+import mindspore.ops as ops
+import mindspore.nn as nn
+
+def enhanced_mixing_loss(y_true, y_pred):
+    gamma = 1.1
+    alpha = 0.48
+    smooth = 1.
+    epsilon = 1e-7
+    y_true_flat = y_true.view(-1)
+    y_pred_flat = y_pred.view(-1)
+    
+    # Dice loss
+    intersection = (y_true_flat * y_pred_flat).sum()
+    dice_score = (2. * intersection + smooth) / (
+        (y_true_flat * y_true_flat).sum() + (y_pred_flat * y_pred_flat).sum() + smooth
+    )
+    dice_loss = 1. - dice_score
+    
+    # Focal loss
+    y_pred_clipped = ops.clip_by_value(y_pred_flat, epsilon, 1. - epsilon)
+    
+    pt_1 = ops.select(ops.equal(y_true_flat, 1.), y_pred_clipped, ops.ones_like(y_pred_clipped))
+    pt_0 = ops.select(ops.equal(y_true_flat, 0.), y_pred_clipped, ops.zeros_like(y_pred_clipped))
+    
+    focal_loss_1 = alpha * ops.pow(1. - pt_1, gamma) * ops.log(pt_1)
+    focal_loss_0 = (1. - alpha) * ops.pow(pt_0, gamma) * ops.log(1. - pt_0)
+    
+    focal_loss = -(focal_loss_1.mean() + focal_loss_0.mean())
+    total_loss = focal_loss + dice_loss
+    
+    return total_loss


### PR DESCRIPTION
This code is a mindspore implementation of D-Unet  

由于测试输入采用的随机数策略有差异，故loss部分输出有区别，不影响功能。  

### MindSpore 运行截图  
![MindSpore](https://github.com/user-attachments/assets/d523a28d-2e48-475c-994a-6d23bbdd02a0)


### Pytorch 运行截图
![Pytorch](https://github.com/user-attachments/assets/0bc3e05c-750a-4e5d-ae1a-b59403d7a039)
